### PR TITLE
tighten intro + projects copy

### DIFF
--- a/src/components/chat/IntroBubble.tsx
+++ b/src/components/chat/IntroBubble.tsx
@@ -60,7 +60,7 @@ export function IntroBubble() {
             animate={{ opacity: 1, filter: 'blur(0px)' }}
             transition={{ duration: 0.8, ease: EASE, delay: 1.0 }}
           >
-            studying Computer Science. I&apos;m a builder exploring distributed systems, local AI, and heavily engineered interfaces. It&apos;s nice to meet you.
+            studying Computer Science &amp; Math.
           </motion.span>
         </p>
       </motion.div>

--- a/src/components/chat/ProjectsSection.tsx
+++ b/src/components/chat/ProjectsSection.tsx
@@ -61,7 +61,7 @@ export function ProjectsSection({ projects }: ProjectsSectionProps) {
                 {/* Header — padded */}
                 <div className="px-4 pt-3 pb-3 border-b border-white/10">
                     <p>
-                        I build things every now and then, often exploring new architectures or scratching my own itch.{' '}
+                        A few things I&apos;ve made.{' '}
                         <span className="text-zinc-500">Hover your mouse here to see the list.</span>
                     </p>
                 </div>

--- a/src/components/chat/ProjectsSection.tsx
+++ b/src/components/chat/ProjectsSection.tsx
@@ -69,7 +69,7 @@ export function ProjectsSection({ projects }: ProjectsSectionProps) {
                 {/* List — no padding, rows own their own px-4 */}
                 <div className="relative pt-1 pb-1">
                     <motion.div
-                        animate={{ height: isOpen ? 'auto' : 96 }}
+                        animate={{ height: isOpen ? 'auto' : 140 }}
                         transition={{ duration: 0.3, ease: [0, 0, 0.2, 1] }}
                         className="overflow-hidden"
                     >
@@ -82,7 +82,7 @@ export function ProjectsSection({ projects }: ProjectsSectionProps) {
                     <motion.div
                         animate={{ opacity: isOpen ? 0 : 1 }}
                         transition={{ duration: 0.15 }}
-                        className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-[#161618] via-[#161618]/80 to-transparent"
+                        className="pointer-events-none absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-[#161618] via-[#161618]/80 to-transparent"
                     />
                 </div>
             </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -20,6 +20,13 @@ export const projects: Project[] = [
     ],
   },
   {
+    title: 'rust-options',
+    description: 'a blazing fast equity derivatives pricing engine in rust. sub-microsecond black-scholes, parallel monte carlo, svi calibration, and a transformer vol surface predictor via onnx.',
+    links: [
+      { label: 'github', href: 'https://github.com/zidankazi/rust-options' },
+    ],
+  },
+  {
     title: 'orbital',
     description: 'real-time satellite tracker for the terminal. renders earth as a 3d ascii globe and tracks satellites utilizing live sgp4 mechanics.',
     links: [
@@ -32,11 +39,6 @@ export const projects: Project[] = [
     links: [
       { label: 'site', href: 'https://zilean.app' },
     ],
-  },
-  {
-    title: 'beatrix',
-    description: 'govcon bid analyzer that scans 30,000+ contracts to surface winning opportunities.',
-    links: [],
   },
   {
     title: 'sage',


### PR DESCRIPTION
## Summary
- Drop the "I'm a builder exploring distributed systems, local AI, and heavily engineered interfaces. It's nice to meet you." line — read as AI-generated.
- Replace projects header "I build things every now and then, often exploring new architectures or scratching my own itch." with "A few things I've made."
- Add Math to the major in the intro.
- Also includes the prior unpushed commit: rust-options swap + peek second project in collapsed list.

## Test plan
- [ ] `npm run dev` and verify intro reads "studying Computer Science & Math." with no trailing builder/greeting line
- [ ] Projects bubble header reads "A few things I've made."
- [ ] Hover-to-expand on projects still works; second project peek visible in collapsed state